### PR TITLE
iostream Fix

### DIFF
--- a/src/ga.cpp
+++ b/src/ga.cpp
@@ -1,6 +1,7 @@
 #include <pdb.hpp>	
 #include <ga.hpp>	
 #include <random>
+#include <iostream>
 
 using namespace std;
 


### PR DESCRIPTION
Avoid "error: ‘cout’ was not declared in this scope"